### PR TITLE
perf : optimize ThWorkerMapper and add unit test

### DIFF
--- a/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
@@ -35,32 +35,45 @@ public class MissionController {
     var thProductsByWorkerCode = missionService.filterThProductsByWorkerCode(workerCode);
     var thProductsByMonth = missionService.thProductsByMonth(thProductsByWorkerCode);
     var thProductsExecutedDaysSumByMonth =
-        missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
+            missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
 
     model.addAttribute("workerCode", workerCode);
     model.addAttribute("months", thProductsByMonth);
     model.addAttribute("products", thProductsByWorkerCode);
     model.addAttribute("total", thProductsExecutedDaysSumByMonth);
     workerToModelAdder.apply(workerCode, model);
+
+    var totalByGroup = new ArrayList<Map<String, Object>>();
+    for (var product : thProductsByWorkerCode) {
+      double sumExecutedDays =
+              product.missions().stream().mapToDouble(mission -> mission.executedDays()).sum();
+      totalByGroup.add(
+              Map.of(
+                      "groupCode", product.code(),
+                      "groupName", product.name(),
+                      "executedDays", sumExecutedDays));
+    }
+    model.addAttribute("totalByGroup", totalByGroup);
+
     return "missions";
   }
 
   @GetMapping("/mission-executions")
   public String getMissionExecutions(
-      Model model,
-      @RequestParam(required = false) String workerCode,
-      @RequestParam(required = false) String yearMonth) {
+          Model model,
+          @RequestParam(required = false) String workerCode,
+          @RequestParam(required = false) String yearMonth) {
     YearMonth month =
-        (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
+            (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
 
     var dailyExecutionsByYearMonth = dailyExecutionsByDate(workerCode, month);
     var thDailyExecutions = new ArrayList<ThDailyExecution>();
     dailyExecutionsByYearMonth.forEach(
-        (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
+            (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
 
     model.addAttribute(
-        "dailyExecutions",
-        thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
+            "dailyExecutions",
+            thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
     model.addAttribute("careProductCode", careProductCodeSupplier.get());
     model.addAttribute("month", month.toString());
     model.addAttribute("workerCode", workerCode);
@@ -70,18 +83,18 @@ public class MissionController {
   }
 
   private Map<LocalDate, List<DailyExecution>> dailyExecutionsByDate(
-      String workerCode, YearMonth month) {
+          String workerCode, YearMonth month) {
     LocalDate startDate = month.atDay(1);
     LocalDate endDate = month.atEndOfMonth();
 
     if (workerCode == null || workerCode.isBlank()) {
       return dailyExecutionRepository.findByDateBetween(startDate, endDate).stream()
-          .collect(groupingBy(DailyExecution::date));
+              .collect(groupingBy(DailyExecution::date));
     } else {
       return dailyExecutionRepository
-          .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
-          .stream()
-          .collect(groupingBy(DailyExecution::date));
+              .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
+              .stream()
+              .collect(groupingBy(DailyExecution::date));
     }
   }
 }

--- a/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
@@ -35,7 +35,7 @@ public class MissionController {
     var thProductsByWorkerCode = missionService.filterThProductsByWorkerCode(workerCode);
     var thProductsByMonth = missionService.thProductsByMonth(thProductsByWorkerCode);
     var thProductsExecutedDaysSumByMonth =
-        missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
+            missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
 
     model.addAttribute("workerCode", workerCode);
     model.addAttribute("months", thProductsByMonth);
@@ -43,16 +43,7 @@ public class MissionController {
     model.addAttribute("total", thProductsExecutedDaysSumByMonth);
     workerToModelAdder.apply(workerCode, model);
 
-    var totalByGroup = new ArrayList<Map<String, Object>>();
-    for (var product : thProductsByWorkerCode) {
-      double sumExecutedDays =
-          product.missions().stream().mapToDouble(mission -> mission.executedDays()).sum();
-      totalByGroup.add(
-          Map.of(
-              "groupCode", product.code(),
-              "groupName", product.name(),
-              "executedDays", sumExecutedDays));
-    }
+    var totalByGroup = missionService.calculateExecutedDaysByGroup(thProductsByWorkerCode);
     model.addAttribute("totalByGroup", totalByGroup);
 
     return "missions";
@@ -60,20 +51,20 @@ public class MissionController {
 
   @GetMapping("/mission-executions")
   public String getMissionExecutions(
-      Model model,
-      @RequestParam(required = false) String workerCode,
-      @RequestParam(required = false) String yearMonth) {
+          Model model,
+          @RequestParam(required = false) String workerCode,
+          @RequestParam(required = false) String yearMonth) {
     YearMonth month =
-        (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
+            (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
 
     var dailyExecutionsByYearMonth = dailyExecutionsByDate(workerCode, month);
     var thDailyExecutions = new ArrayList<ThDailyExecution>();
     dailyExecutionsByYearMonth.forEach(
-        (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
+            (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
 
     model.addAttribute(
-        "dailyExecutions",
-        thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
+            "dailyExecutions",
+            thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
     model.addAttribute("careProductCode", careProductCodeSupplier.get());
     model.addAttribute("month", month.toString());
     model.addAttribute("workerCode", workerCode);
@@ -83,18 +74,18 @@ public class MissionController {
   }
 
   private Map<LocalDate, List<DailyExecution>> dailyExecutionsByDate(
-      String workerCode, YearMonth month) {
+          String workerCode, YearMonth month) {
     LocalDate startDate = month.atDay(1);
     LocalDate endDate = month.atEndOfMonth();
 
     if (workerCode == null || workerCode.isBlank()) {
       return dailyExecutionRepository.findByDateBetween(startDate, endDate).stream()
-          .collect(groupingBy(DailyExecution::date));
+              .collect(groupingBy(DailyExecution::date));
     } else {
       return dailyExecutionRepository
-          .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
-          .stream()
-          .collect(groupingBy(DailyExecution::date));
+              .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
+              .stream()
+              .collect(groupingBy(DailyExecution::date));
     }
   }
 }

--- a/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
@@ -43,8 +43,8 @@ public class MissionController {
     model.addAttribute("total", thProductsExecutedDaysSumByMonth);
     workerToModelAdder.apply(workerCode, model);
 
-    var totalByGroup = missionService.calculateExecutedDaysByGroup(thProductsByWorkerCode);
-    model.addAttribute("totalByGroup", totalByGroup);
+    var executedDaysByProduct = missionService.calculateExecutedDaysByProduct(thProductsByWorkerCode);
+    model.addAttribute("executedDaysByProduct", executedDaysByProduct);
 
     return "missions";
   }

--- a/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
@@ -43,7 +43,8 @@ public class MissionController {
     model.addAttribute("total", thProductsExecutedDaysSumByMonth);
     workerToModelAdder.apply(workerCode, model);
 
-    var executedDaysByProduct = missionService.calculateExecutedDaysByProduct(thProductsByWorkerCode);
+    var executedDaysByProduct =
+        missionService.calculateExecutedDaysByProduct(thProductsByWorkerCode);
     model.addAttribute("executedDaysByProduct", executedDaysByProduct);
 
     return "missions";

--- a/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
@@ -35,7 +35,7 @@ public class MissionController {
     var thProductsByWorkerCode = missionService.filterThProductsByWorkerCode(workerCode);
     var thProductsByMonth = missionService.thProductsByMonth(thProductsByWorkerCode);
     var thProductsExecutedDaysSumByMonth =
-            missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
+        missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
 
     model.addAttribute("workerCode", workerCode);
     model.addAttribute("months", thProductsByMonth);
@@ -46,12 +46,12 @@ public class MissionController {
     var totalByGroup = new ArrayList<Map<String, Object>>();
     for (var product : thProductsByWorkerCode) {
       double sumExecutedDays =
-              product.missions().stream().mapToDouble(mission -> mission.executedDays()).sum();
+          product.missions().stream().mapToDouble(mission -> mission.executedDays()).sum();
       totalByGroup.add(
-              Map.of(
-                      "groupCode", product.code(),
-                      "groupName", product.name(),
-                      "executedDays", sumExecutedDays));
+          Map.of(
+              "groupCode", product.code(),
+              "groupName", product.name(),
+              "executedDays", sumExecutedDays));
     }
     model.addAttribute("totalByGroup", totalByGroup);
 
@@ -60,20 +60,20 @@ public class MissionController {
 
   @GetMapping("/mission-executions")
   public String getMissionExecutions(
-          Model model,
-          @RequestParam(required = false) String workerCode,
-          @RequestParam(required = false) String yearMonth) {
+      Model model,
+      @RequestParam(required = false) String workerCode,
+      @RequestParam(required = false) String yearMonth) {
     YearMonth month =
-            (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
+        (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
 
     var dailyExecutionsByYearMonth = dailyExecutionsByDate(workerCode, month);
     var thDailyExecutions = new ArrayList<ThDailyExecution>();
     dailyExecutionsByYearMonth.forEach(
-            (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
+        (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
 
     model.addAttribute(
-            "dailyExecutions",
-            thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
+        "dailyExecutions",
+        thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
     model.addAttribute("careProductCode", careProductCodeSupplier.get());
     model.addAttribute("month", month.toString());
     model.addAttribute("workerCode", workerCode);
@@ -83,18 +83,18 @@ public class MissionController {
   }
 
   private Map<LocalDate, List<DailyExecution>> dailyExecutionsByDate(
-          String workerCode, YearMonth month) {
+      String workerCode, YearMonth month) {
     LocalDate startDate = month.atDay(1);
     LocalDate endDate = month.atEndOfMonth();
 
     if (workerCode == null || workerCode.isBlank()) {
       return dailyExecutionRepository.findByDateBetween(startDate, endDate).stream()
-              .collect(groupingBy(DailyExecution::date));
+          .collect(groupingBy(DailyExecution::date));
     } else {
       return dailyExecutionRepository
-              .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
-              .stream()
-              .collect(groupingBy(DailyExecution::date));
+          .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
+          .stream()
+          .collect(groupingBy(DailyExecution::date));
     }
   }
 }

--- a/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/MissionController.java
@@ -35,7 +35,7 @@ public class MissionController {
     var thProductsByWorkerCode = missionService.filterThProductsByWorkerCode(workerCode);
     var thProductsByMonth = missionService.thProductsByMonth(thProductsByWorkerCode);
     var thProductsExecutedDaysSumByMonth =
-            missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
+        missionService.thProductsExecutedDaysSumByMonth(thProductsByWorkerCode);
 
     model.addAttribute("workerCode", workerCode);
     model.addAttribute("months", thProductsByMonth);
@@ -51,20 +51,20 @@ public class MissionController {
 
   @GetMapping("/mission-executions")
   public String getMissionExecutions(
-          Model model,
-          @RequestParam(required = false) String workerCode,
-          @RequestParam(required = false) String yearMonth) {
+      Model model,
+      @RequestParam(required = false) String workerCode,
+      @RequestParam(required = false) String yearMonth) {
     YearMonth month =
-            (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
+        (yearMonth == null || yearMonth.isBlank()) ? YearMonth.now() : YearMonth.parse(yearMonth);
 
     var dailyExecutionsByYearMonth = dailyExecutionsByDate(workerCode, month);
     var thDailyExecutions = new ArrayList<ThDailyExecution>();
     dailyExecutionsByYearMonth.forEach(
-            (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
+        (date, deList) -> thDailyExecutions.add(thDailyExecutionMapper.toTh(date, deList)));
 
     model.addAttribute(
-            "dailyExecutions",
-            thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
+        "dailyExecutions",
+        thDailyExecutions.stream().sorted(comparing(ThDailyExecution::date).reversed()).toList());
     model.addAttribute("careProductCode", careProductCodeSupplier.get());
     model.addAttribute("month", month.toString());
     model.addAttribute("workerCode", workerCode);
@@ -74,18 +74,18 @@ public class MissionController {
   }
 
   private Map<LocalDate, List<DailyExecution>> dailyExecutionsByDate(
-          String workerCode, YearMonth month) {
+      String workerCode, YearMonth month) {
     LocalDate startDate = month.atDay(1);
     LocalDate endDate = month.atEndOfMonth();
 
     if (workerCode == null || workerCode.isBlank()) {
       return dailyExecutionRepository.findByDateBetween(startDate, endDate).stream()
-              .collect(groupingBy(DailyExecution::date));
+          .collect(groupingBy(DailyExecution::date));
     } else {
       return dailyExecutionRepository
-              .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
-              .stream()
-              .collect(groupingBy(DailyExecution::date));
+          .findByWorkerCodeAndDateBetween(workerCode, startDate, endDate)
+          .stream()
+          .collect(groupingBy(DailyExecution::date));
     }
   }
 }

--- a/src/main/java/school/hei/asa/endpoint/rest/controller/mapper/ThWorkerMapper.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/mapper/ThWorkerMapper.java
@@ -4,9 +4,8 @@ import static java.time.Instant.now;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import school.hei.asa.CareProductCodeSupplier;
@@ -24,32 +23,53 @@ public class ThWorkerMapper {
   private final CareProductCodeSupplier careProductCodeSupplier;
 
   public List<ThWorkerLevelHistory> toTh(List<WorkerLevelHistory> histories) {
+    if (histories.isEmpty()) {
+      return List.of();
+    }
+
     ZoneId zoneId = ZoneId.of("UTC");
+    Worker worker = histories.get(0).worker();
+
+    LocalDate minDate = histories.stream()
+            .map(h -> h.entranceInstant().atZone(zoneId).toLocalDate())
+            .min(LocalDate::compareTo)
+            .orElse(LocalDate.now());
+
+    LocalDate maxDate = LocalDate.now();
+
+    Map<LocalDate, Double> missionByDate = missionExecutionRepository
+            .missionExecutionsByDateBetween(worker, minDate, maxDate)
+            .stream()
+            .filter(me -> !isCare(me))
+            .collect(Collectors.groupingBy(
+                    MissionExecution::date,
+                    Collectors.summingDouble(MissionExecution::dayPercentage)
+            ));
+
     List<ThWorkerLevelHistory> result = new ArrayList<>();
 
     for (int i = 0; i < histories.size(); i++) {
       var current = histories.get(i);
       var nextEntrance = (i == 0) ? now() : histories.get(i - 1).entranceInstant();
 
-      double totalDaysWorked =
-          missionExecutionPercentageSumByWorker(
-              current.worker(),
-              current.entranceInstant().atZone(zoneId).toLocalDate(),
-              nextEntrance.atZone(zoneId).toLocalDate());
+      LocalDate start = current.entranceInstant().atZone(zoneId).toLocalDate();
+      LocalDate end = nextEntrance.atZone(zoneId).toLocalDate();
 
-      var contractType = toWorkerType(current.contractType());
-      var totalWorkDays = Objects.toString(current.projectedDaysToWork(), "-");
+      double totalDaysWorked = missionByDate.entrySet().stream()
+              .filter(e -> !e.getKey().isBefore(start) && !e.getKey().isAfter(end))
+              .mapToDouble(Map.Entry::getValue)
+              .sum();
 
-      result.add(
-          new ThWorkerLevelHistory(
+      result.add(new ThWorkerLevelHistory(
               current.level().getLevel(),
               current.entranceInstant(),
-              contractType,
-              totalWorkDays,
+              toWorkerType(current.contractType()),
+              Objects.toString(current.projectedDaysToWork(), "-"),
               String.valueOf(totalDaysWorked),
               current.salary(),
               current.jobTitle(),
-              current.contractDuration()));
+              current.contractDuration()
+      ));
     }
 
     return result;
@@ -64,18 +84,7 @@ public class ThWorkerMapper {
     };
   }
 
-  private Double missionExecutionPercentageSumByWorker(
-      Worker worker, LocalDate startDate, LocalDate endDate) {
-    return missionExecutionRepository
-        .missionExecutionsByDateBetween(worker, startDate, endDate)
-        .stream()
-        .filter(me -> !isCare(me))
-        .mapToDouble(MissionExecution::dayPercentage)
-        .sum();
-  }
-
   private boolean isCare(MissionExecution me) {
-    var mission = me.mission();
-    return mission.isCare(careProductCodeSupplier.get());
+    return me.mission().isCare(careProductCodeSupplier.get());
   }
 }

--- a/src/main/java/school/hei/asa/endpoint/rest/controller/mapper/ThWorkerMapper.java
+++ b/src/main/java/school/hei/asa/endpoint/rest/controller/mapper/ThWorkerMapper.java
@@ -30,21 +30,21 @@ public class ThWorkerMapper {
     ZoneId zoneId = ZoneId.of("UTC");
     Worker worker = histories.get(0).worker();
 
-    LocalDate minDate = histories.stream()
+    LocalDate minDate =
+        histories.stream()
             .map(h -> h.entranceInstant().atZone(zoneId).toLocalDate())
             .min(LocalDate::compareTo)
             .orElse(LocalDate.now());
 
     LocalDate maxDate = LocalDate.now();
 
-    Map<LocalDate, Double> missionByDate = missionExecutionRepository
-            .missionExecutionsByDateBetween(worker, minDate, maxDate)
-            .stream()
+    Map<LocalDate, Double> missionByDate =
+        missionExecutionRepository.missionExecutionsByDateBetween(worker, minDate, maxDate).stream()
             .filter(me -> !isCare(me))
-            .collect(Collectors.groupingBy(
+            .collect(
+                Collectors.groupingBy(
                     MissionExecution::date,
-                    Collectors.summingDouble(MissionExecution::dayPercentage)
-            ));
+                    Collectors.summingDouble(MissionExecution::dayPercentage)));
 
     List<ThWorkerLevelHistory> result = new ArrayList<>();
 
@@ -55,12 +55,14 @@ public class ThWorkerMapper {
       LocalDate start = current.entranceInstant().atZone(zoneId).toLocalDate();
       LocalDate end = nextEntrance.atZone(zoneId).toLocalDate();
 
-      double totalDaysWorked = missionByDate.entrySet().stream()
+      double totalDaysWorked =
+          missionByDate.entrySet().stream()
               .filter(e -> !e.getKey().isBefore(start) && !e.getKey().isAfter(end))
               .mapToDouble(Map.Entry::getValue)
               .sum();
 
-      result.add(new ThWorkerLevelHistory(
+      result.add(
+          new ThWorkerLevelHistory(
               current.level().getLevel(),
               current.entranceInstant(),
               toWorkerType(current.contractType()),
@@ -68,8 +70,7 @@ public class ThWorkerMapper {
               String.valueOf(totalDaysWorked),
               current.salary(),
               current.jobTitle(),
-              current.contractDuration()
-      ));
+              current.contractDuration()));
     }
 
     return result;

--- a/src/main/java/school/hei/asa/service/MissionService.java
+++ b/src/main/java/school/hei/asa/service/MissionService.java
@@ -65,7 +65,7 @@ public class MissionService {
     return res;
   }
 
-    public List<Map<String, Object>> calculateExecutedDaysByProduct(List<ThProduct> products) {
+  public List<Map<String, Object>> calculateExecutedDaysByProduct(List<ThProduct> products) {
     List<Map<String, Object>> result = new ArrayList<>();
 
     for (var product : products) {

--- a/src/main/java/school/hei/asa/service/MissionService.java
+++ b/src/main/java/school/hei/asa/service/MissionService.java
@@ -65,7 +65,7 @@ public class MissionService {
     return res;
   }
 
-  public List<Map<String, Object>> calculateExecutedDaysByGroup(List<ThProduct> products) {
+    public List<Map<String, Object>> calculateExecutedDaysByProduct(List<ThProduct> products) {
     List<Map<String, Object>> result = new ArrayList<>();
 
     for (var product : products) {

--- a/src/main/java/school/hei/asa/service/MissionService.java
+++ b/src/main/java/school/hei/asa/service/MissionService.java
@@ -12,63 +12,81 @@ import school.hei.asa.repository.ProductRepository;
 @Service
 public class MissionService {
 
-  private final ProductRepository productRepository;
-  private final ThProductMapper thProductMapper;
+    private final ProductRepository productRepository;
+    private final ThProductMapper thProductMapper;
 
-  public List<ThProduct> filterThProductsByWorkerCode(String workerCode) {
-    var thProducts = thProductMapper.toTh(productRepository.findAll());
-    return workerCode == null || workerCode.isBlank()
-        ? thProducts
-        : thProducts.stream().map(p -> p.filterByWorkerCode(workerCode)).toList();
-  }
+    public List<ThProduct> filterThProductsByWorkerCode(String workerCode) {
+        var thProducts = thProductMapper.toTh(productRepository.findAll());
+        return workerCode == null || workerCode.isBlank()
+                ? thProducts
+                : thProducts.stream().map(p -> p.filterByWorkerCode(workerCode)).toList();
+    }
 
-  public Map<String, List<ThProduct>> thProductsByMonth(List<ThProduct> thProducts) {
-    EnumSet<Month> months = EnumSet.allOf(Month.class);
-    Map<String, List<ThProduct>> res = new LinkedHashMap<>();
-    months.forEach(
-        (month) -> {
-          List<ThProduct> monthProducts =
-              thProducts.stream()
-                  .map(p -> p.filterByMonth(month))
-                  .filter(Objects::nonNull)
-                  .toList();
+    public Map<String, List<ThProduct>> thProductsByMonth(List<ThProduct> thProducts) {
+        EnumSet<Month> months = EnumSet.allOf(Month.class);
+        Map<String, List<ThProduct>> res = new LinkedHashMap<>();
+        months.forEach(
+                (month) -> {
+                    List<ThProduct> monthProducts =
+                            thProducts.stream()
+                                    .map(p -> p.filterByMonth(month))
+                                    .filter(Objects::nonNull)
+                                    .toList();
 
-          var hasExecutedDays =
-              monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
+                    var hasExecutedDays =
+                            monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
 
-          if (hasExecutedDays) {
-            res.putIfAbsent(month.toString().toLowerCase(), monthProducts);
-          }
-        });
-    return res;
-  }
+                    if (hasExecutedDays) {
+                        res.putIfAbsent(month.toString().toLowerCase(), monthProducts);
+                    }
+                });
+        return res;
+    }
 
-  public Map<String, Double> thProductsExecutedDaysSumByMonth(List<ThProduct> thProducts) {
-    EnumSet<Month> months = EnumSet.allOf(Month.class);
-    Map<String, Double> res = new LinkedHashMap<>();
-    months.forEach(
-        (month) -> {
-          List<ThProduct> monthProducts =
-              thProducts.stream()
-                  .map(p -> p.filterByMonth(month))
-                  .filter(Objects::nonNull)
-                  .toList();
+    public Map<String, Double> thProductsExecutedDaysSumByMonth(List<ThProduct> thProducts) {
+        EnumSet<Month> months = EnumSet.allOf(Month.class);
+        Map<String, Double> res = new LinkedHashMap<>();
+        months.forEach(
+                (month) -> {
+                    List<ThProduct> monthProducts =
+                            thProducts.stream()
+                                    .map(p -> p.filterByMonth(month))
+                                    .filter(Objects::nonNull)
+                                    .toList();
 
-          var hasExecutedDays =
-              monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
+                    var hasExecutedDays =
+                            monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
 
-          if (hasExecutedDays) {
-            res.putIfAbsent(
-                month.toString().toLowerCase(), thProductsExecutedDaysSum(monthProducts, month));
-          }
-        });
-    return res;
-  }
+                    if (hasExecutedDays) {
+                        res.putIfAbsent(
+                                month.toString().toLowerCase(), thProductsExecutedDaysSum(monthProducts, month));
+                    }
+                });
+        return res;
+    }
 
-  public Double thProductsExecutedDaysSum(List<ThProduct> thProducts, Month month) {
-    return thProducts.stream()
-        .map(p -> p.filterByMonth(month))
-        .mapToDouble(ThProduct::executedDays)
-        .sum();
-  }
+    public List<Map<String, Object>> calculateExecutedDaysByGroup(List<ThProduct> products) {
+        List<Map<String, Object>> result = new ArrayList<>();
+
+        for (var product : products) {
+            double sumExecutedDays = product.missions().stream()
+                    .mapToDouble(mission -> mission.executedDays())
+                    .sum();
+
+            result.add(Map.of(
+                    "groupCode", product.code(),
+                    "groupName", product.name(),
+                    "executedDaysByProduct", sumExecutedDays
+            ));
+        }
+
+        return result;
+    }
+
+    public Double thProductsExecutedDaysSum(List<ThProduct> thProducts, Month month) {
+        return thProducts.stream()
+                .map(p -> p.filterByMonth(month))
+                .mapToDouble(ThProduct::executedDays)
+                .sum();
+    }
 }

--- a/src/main/java/school/hei/asa/service/MissionService.java
+++ b/src/main/java/school/hei/asa/service/MissionService.java
@@ -12,81 +12,80 @@ import school.hei.asa.repository.ProductRepository;
 @Service
 public class MissionService {
 
-    private final ProductRepository productRepository;
-    private final ThProductMapper thProductMapper;
+  private final ProductRepository productRepository;
+  private final ThProductMapper thProductMapper;
 
-    public List<ThProduct> filterThProductsByWorkerCode(String workerCode) {
-        var thProducts = thProductMapper.toTh(productRepository.findAll());
-        return workerCode == null || workerCode.isBlank()
-                ? thProducts
-                : thProducts.stream().map(p -> p.filterByWorkerCode(workerCode)).toList();
+  public List<ThProduct> filterThProductsByWorkerCode(String workerCode) {
+    var thProducts = thProductMapper.toTh(productRepository.findAll());
+    return workerCode == null || workerCode.isBlank()
+        ? thProducts
+        : thProducts.stream().map(p -> p.filterByWorkerCode(workerCode)).toList();
+  }
+
+  public Map<String, List<ThProduct>> thProductsByMonth(List<ThProduct> thProducts) {
+    EnumSet<Month> months = EnumSet.allOf(Month.class);
+    Map<String, List<ThProduct>> res = new LinkedHashMap<>();
+    months.forEach(
+        (month) -> {
+          List<ThProduct> monthProducts =
+              thProducts.stream()
+                  .map(p -> p.filterByMonth(month))
+                  .filter(Objects::nonNull)
+                  .toList();
+
+          var hasExecutedDays =
+              monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
+
+          if (hasExecutedDays) {
+            res.putIfAbsent(month.toString().toLowerCase(), monthProducts);
+          }
+        });
+    return res;
+  }
+
+  public Map<String, Double> thProductsExecutedDaysSumByMonth(List<ThProduct> thProducts) {
+    EnumSet<Month> months = EnumSet.allOf(Month.class);
+    Map<String, Double> res = new LinkedHashMap<>();
+    months.forEach(
+        (month) -> {
+          List<ThProduct> monthProducts =
+              thProducts.stream()
+                  .map(p -> p.filterByMonth(month))
+                  .filter(Objects::nonNull)
+                  .toList();
+
+          var hasExecutedDays =
+              monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
+
+          if (hasExecutedDays) {
+            res.putIfAbsent(
+                month.toString().toLowerCase(), thProductsExecutedDaysSum(monthProducts, month));
+          }
+        });
+    return res;
+  }
+
+  public List<Map<String, Object>> calculateExecutedDaysByGroup(List<ThProduct> products) {
+    List<Map<String, Object>> result = new ArrayList<>();
+
+    for (var product : products) {
+      double sumExecutedDays =
+          product.missions().stream().mapToDouble(mission -> mission.executedDays()).sum();
+
+      result.add(
+          Map.of(
+              "groupCode", product.code(),
+              "groupName", product.name(),
+              "executedDaysByProduct", sumExecutedDays));
     }
 
-    public Map<String, List<ThProduct>> thProductsByMonth(List<ThProduct> thProducts) {
-        EnumSet<Month> months = EnumSet.allOf(Month.class);
-        Map<String, List<ThProduct>> res = new LinkedHashMap<>();
-        months.forEach(
-                (month) -> {
-                    List<ThProduct> monthProducts =
-                            thProducts.stream()
-                                    .map(p -> p.filterByMonth(month))
-                                    .filter(Objects::nonNull)
-                                    .toList();
+    return result;
+  }
 
-                    var hasExecutedDays =
-                            monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
-
-                    if (hasExecutedDays) {
-                        res.putIfAbsent(month.toString().toLowerCase(), monthProducts);
-                    }
-                });
-        return res;
-    }
-
-    public Map<String, Double> thProductsExecutedDaysSumByMonth(List<ThProduct> thProducts) {
-        EnumSet<Month> months = EnumSet.allOf(Month.class);
-        Map<String, Double> res = new LinkedHashMap<>();
-        months.forEach(
-                (month) -> {
-                    List<ThProduct> monthProducts =
-                            thProducts.stream()
-                                    .map(p -> p.filterByMonth(month))
-                                    .filter(Objects::nonNull)
-                                    .toList();
-
-                    var hasExecutedDays =
-                            monthProducts.stream().mapToDouble(ThProduct::executedDays).sum() > 0;
-
-                    if (hasExecutedDays) {
-                        res.putIfAbsent(
-                                month.toString().toLowerCase(), thProductsExecutedDaysSum(monthProducts, month));
-                    }
-                });
-        return res;
-    }
-
-    public List<Map<String, Object>> calculateExecutedDaysByGroup(List<ThProduct> products) {
-        List<Map<String, Object>> result = new ArrayList<>();
-
-        for (var product : products) {
-            double sumExecutedDays = product.missions().stream()
-                    .mapToDouble(mission -> mission.executedDays())
-                    .sum();
-
-            result.add(Map.of(
-                    "groupCode", product.code(),
-                    "groupName", product.name(),
-                    "executedDaysByProduct", sumExecutedDays
-            ));
-        }
-
-        return result;
-    }
-
-    public Double thProductsExecutedDaysSum(List<ThProduct> thProducts, Month month) {
-        return thProducts.stream()
-                .map(p -> p.filterByMonth(month))
-                .mapToDouble(ThProduct::executedDays)
-                .sum();
-    }
+  public Double thProductsExecutedDaysSum(List<ThProduct> thProducts, Month month) {
+    return thProducts.stream()
+        .map(p -> p.filterByMonth(month))
+        .mapToDouble(ThProduct::executedDays)
+        .sum();
+  }
 }

--- a/src/main/resources/static/main.css
+++ b/src/main/resources/static/main.css
@@ -60,3 +60,20 @@ th {
     padding-top: 0.5rem;
     padding-inline: 0.5rem;
 }
+
+.btn-primary {
+    padding: 0.5rem 1.25rem; /* px-5 py-2 */
+    background-color: #1e3a8a; /* bg-blue-900 */
+    color: white; /* text-white */
+    font-weight: 600; /* font-semibold */
+    border-radius: 0.5rem; /* rounded-lg */
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2); /* shadow-md */
+    transition: all 0.3s ease; /* transition-all duration-300 */
+}
+
+.btn-primary:hover {
+    background-color: #1d4ed8; /* hover:bg-blue-700 */
+    transform: scale(1.05); /* hover:scale-105 */
+    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.3); /* hover:shadow-xl */
+}
+

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -120,7 +120,7 @@
 </div>
 
 <script th:inline="javascript">
-    const groups = /*[[${totalByGroup}]]*/ [];
+    const groups = /*[[${executedDaysByProduct}]]*/ [];
 
     const modal = document.getElementById('graphModal');
     const openModalBtn = document.getElementById('openModalBtn');

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -15,12 +15,7 @@
     <h2 class="text-xl font-bold mb-2">Worker</h2>
     <div class="ml-6 mr-6 mt-6 flex justify-between items-center">
         <div th:replace="fragments/workerSelector :: workerSelector(missions, All)"></div>
-
-        <button id="openModalBtn"
-                class="px-5 py-2 bg-blue-900 text-white font-semibold rounded-lg shadow-md transition-all duration-300 hover:bg-blue-700 hover:scale-105 hover:shadow-xl"
-                style="border: 2px solid white;">
-             Show Graphic
-        </button>
+        <button id="openModalBtn" class="btn-primary">Show Graph</button>
     </div>
 
 

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -13,7 +13,16 @@
 
 <div class="ml-6 mr-6 mt-6">
     <h2 class="text-xl font-bold mb-2">Worker</h2>
-    <div th:replace="fragments/workerSelector :: workerSelector(missions, All)"></div>
+    <div class="ml-6 mr-6 mt-6 flex justify-between items-center">
+        <div th:replace="fragments/workerSelector :: workerSelector(missions, All)"></div>
+
+        <button id="openModalBtn"
+                class="px-5 py-2 bg-blue-900 text-white font-semibold rounded-lg shadow-md transition-all duration-300 hover:bg-blue-700 hover:scale-105 hover:shadow-xl"
+                style="border: 2px solid white;">
+            🚀 Show Graph
+        </button>
+    </div>
+
 
     <h2 class="text-xl font-bold mt-6" th:text="'Missions by Products - ' + ${worker == null ? 'All' : worker.name()}"></h2>
     <strong>"st="</strong> refers to days executed by a <strong>st</strong>udent worker.
@@ -92,19 +101,13 @@
     </script>
 </div>
 
-<div class="ml-6 mr-6">
-    <button id="openModalBtn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-800">
-        Show Graph
-    </button>
-</div>
-
 <!-- Modal -->
 <div id="graphModal" class="fixed inset-0 z-50 hidden bg-black bg-opacity-50 flex items-center justify-center">
     <div class="bg-white rounded-lg p-6 w-full max-w-5xl h-[90vh] relative flex flex-col">
         <button id="closeModalBtn" class="absolute top-2 right-2 text-gray-600 hover:text-black text-xl">
             &times;
         </button>
-        <h2 class="text-2xl font-semibold mb-4">Pie Chart: Total time per mission group</h2>
+        <h2 class="text-2xl font-semibold mb-4">Total time per mission group</h2>
 
         <div id="missionsChart" class="flex-grow" style="width: 100%; height: 100%;"></div>
 

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -19,7 +19,7 @@
         <button id="openModalBtn"
                 class="px-5 py-2 bg-blue-900 text-white font-semibold rounded-lg shadow-md transition-all duration-300 hover:bg-blue-700 hover:scale-105 hover:shadow-xl"
                 style="border: 2px solid white;">
-            🚀 Show Graph
+             Show Graphic
         </button>
     </div>
 
@@ -154,10 +154,12 @@
                     type: 'pie',
                     radius: '70%',
                     center: ['60%', '50%'],
-                    data: groups.map(g => ({
-                        name: g.groupName,
-                        value: parseFloat(parseFloat(g.executedDaysByProduct).toFixed(1))
-                    })),
+                    data: groups
+                        .filter(g => parseFloat(g.executedDaysByProduct) > 0)
+                        .map(g => ({
+                            name: g.groupName,
+                            value: parseFloat(parseFloat(g.executedDaysByProduct).toFixed(1))
+                        })),
                     label: {
                         formatter: '{b}: {c} j',
                         fontSize: 14

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -5,6 +5,7 @@
     <link href="/main.css" rel="stylesheet"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-800">
@@ -77,7 +78,6 @@
             </td>
         </tr>
         </tfoot>
-
     </table>
 
     <script>
@@ -91,6 +91,101 @@
         });
     </script>
 </div>
+
+<div class="ml-6 mr-6">
+    <div class="flex justify-between items-center mb-4">
+        <h2 class="text-2xl font-semibold">Graph: Total time spent per mission group</h2>
+        <button id="downloadBtn" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700">
+            Download
+        </button>
+    </div>
+    <div id="missionsChart" style="width: 100%; height: 500px;"></div>
+</div>
+
+<script th:inline="javascript">
+    const groups = /*[[${totalByGroup}]]*/ [];
+
+    const chartDom = document.getElementById('missionsChart');
+
+    if (groups.length === 0) {
+        chartDom.innerHTML = '<p style="text-align:center; padding:50px;">Aucune donnée à afficher</p>';
+    } else {
+        const myChart = echarts.init(chartDom);
+
+        const colors = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#6366f1', '#14b8a6'];
+
+        const sortedGroups = groups.slice().sort((a, b) => parseFloat(a.executedDays) - parseFloat(b.executedDays));
+
+        const option = {
+            tooltip: {
+                trigger: 'axis',
+                axisPointer: { type: 'shadow' },
+                formatter: function (params) {
+                    const data = params[0];
+                    return `<strong>${data.name}</strong><br/>Jours exécutés : ${data.value}`;
+                }
+            },
+            grid: {
+                left: '5%',
+                right: '5%',
+                bottom: '10%',
+                containLabel: true
+            },
+            xAxis: {
+                type: 'value',
+                name: 'Days'
+            },
+            yAxis: {
+                type: 'category',
+                data: sortedGroups.map(g => g.groupName),
+                axisLabel: {
+                    interval: 0,
+                    formatter: value => value.length > 20 ? value.slice(0, 20) + '…' : value
+                }
+            },
+            series: [{
+                type: 'bar',
+                data: sortedGroups.map((g, i) => ({
+                    value: parseFloat(parseFloat(g.executedDays).toFixed(1)),
+                    itemStyle: {
+                        color: colors[i % colors.length],
+                        borderRadius: [0, 6, 6, 0]
+                    }
+                })),
+                label: {
+                    show: true,
+                    position: 'right',
+                    formatter: function (params) {
+                        return parseFloat(params.value).toFixed(1);
+                    }
+                }
+            }]
+        };
+
+        myChart.setOption(option);
+
+        window.addEventListener('resize', () => {
+            myChart.resize();
+        });
+
+        document.getElementById('downloadBtn').addEventListener('click', () => {
+            const a = document.createElement('a');
+            a.href = myChart.getDataURL({
+                type: 'png',
+                pixelRatio: 2,
+                backgroundColor: '#fff'
+            });
+            a.download = 'missions_graph.png';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+        });
+    }
+</script>
+
+
+
+
 
 </body>
 </html>

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -83,7 +83,7 @@
     <script>
         function updateFilters() {
             const workerCode = document.getElementById("worker").value;
-            window.location.href = `/missions?workerCode=${workerCode}`;
+            window.location.href = /missions?workerCode=${workerCode};
         }
 
         document.addEventListener("DOMContentLoaded", function() {
@@ -93,96 +93,106 @@
 </div>
 
 <div class="ml-6 mr-6">
-    <div class="flex justify-between items-center mb-4">
-        <h2 class="text-2xl font-semibold">Graph: Total time spent per mission group</h2>
-        <button id="downloadBtn" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700">
-            Download
+    <button id="openModalBtn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-800">
+        Show Graph
+    </button>
+</div>
+
+<!-- Modal -->
+<div id="graphModal" class="fixed inset-0 z-50 hidden bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="bg-white rounded-lg p-6 w-full max-w-3xl relative">
+        <button id="closeModalBtn" class="absolute top-2 right-2 text-gray-600 hover:text-black text-xl">
+            &times;
         </button>
+        <div class="flex justify-between items-center mb-4">
+            <h2 class="text-2xl font-semibold">Pie Chart: Total time per mission group</h2>
+            <button id="downloadBtn" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700">
+                Download
+            </button>
+        </div>
+        <div id="missionsChart" style="width: 100%; height: 500px;"></div>
     </div>
-    <div id="missionsChart" style="width: 100%; height: 500px;"></div>
 </div>
 
 <script th:inline="javascript">
     const groups = /*[[${totalByGroup}]]*/ [];
 
+    const modal = document.getElementById('graphModal');
+    const openModalBtn = document.getElementById('openModalBtn');
+    const closeModalBtn = document.getElementById('closeModalBtn');
     const chartDom = document.getElementById('missionsChart');
+    let myChart;
 
-    if (groups.length === 0) {
-        chartDom.innerHTML = '<p style="text-align:center; padding:50px;">Aucune donnée à afficher</p>';
-    } else {
-        const myChart = echarts.init(chartDom);
+    openModalBtn.addEventListener('click', () => {
+        modal.classList.remove('hidden');
 
-        const colors = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#6366f1', '#14b8a6'];
+        if (!groups || groups.length === 0) {
+            chartDom.innerHTML = '<p style="text-align:center; padding:50px;">Aucune donnée à afficher</p>';
+            return;
+        }
 
-        const sortedGroups = groups.slice().sort((a, b) => parseFloat(a.executedDays) - parseFloat(b.executedDays));
+        if (!myChart) {
+            myChart = echarts.init(chartDom);
 
-        const option = {
-            tooltip: {
-                trigger: 'axis',
-                axisPointer: { type: 'shadow' },
-                formatter: function (params) {
-                    const data = params[0];
-                    return `<strong>${data.name}</strong><br/>Jours exécutés : ${data.value}`;
-                }
-            },
-            grid: {
-                left: '5%',
-                right: '5%',
-                bottom: '10%',
-                containLabel: true
-            },
-            xAxis: {
-                type: 'value',
-                name: 'Days'
-            },
-            yAxis: {
-                type: 'category',
-                data: sortedGroups.map(g => g.groupName),
-                axisLabel: {
-                    interval: 0,
-                    formatter: value => value.length > 20 ? value.slice(0, 20) + '…' : value
-                }
-            },
-            series: [{
-                type: 'bar',
-                data: sortedGroups.map((g, i) => ({
-                    value: parseFloat(parseFloat(g.executedDays).toFixed(1)),
+            const option = {
+                tooltip: {
+                    trigger: 'item',
+                    formatter: '{b}: {c} jours ({d}%)'
+                },
+                legend: {
+                    orient: 'vertical',
+                    left: 'left'
+                },
+                series: [{
+                    name: 'Jours exécutés',
+                    type: 'pie',
+                    radius: '70%',
+                    center: ['60%', '50%'],
+                    data: groups.map(g => ({
+                        name: g.groupName,
+                        value: parseFloat(parseFloat(g.executedDaysByProduct).toFixed(1))
+                    })),
+                    label: {
+                        formatter: '{b}: {c} j',
+                        fontSize: 14
+                    },
                     itemStyle: {
-                        color: colors[i % colors.length],
-                        borderRadius: [0, 6, 6, 0]
+                        borderRadius: 6,
+                        borderColor: '#fff',
+                        borderWidth: 2
                     }
-                })),
-                label: {
-                    show: true,
-                    position: 'right',
-                    formatter: function (params) {
-                        return parseFloat(params.value).toFixed(1);
-                    }
-                }
-            }]
-        };
+                }]
+            };
 
-        myChart.setOption(option);
-
-        window.addEventListener('resize', () => {
+            myChart.setOption(option);
+        } else {
             myChart.resize();
-        });
+        }
+    });
 
-        document.getElementById('downloadBtn').addEventListener('click', () => {
+    closeModalBtn.addEventListener('click', () => {
+        modal.classList.add('hidden');
+    });
+
+    window.addEventListener('resize', () => {
+        if (myChart) myChart.resize();
+    });
+
+    document.getElementById('downloadBtn').addEventListener('click', () => {
+        if (myChart) {
             const a = document.createElement('a');
             a.href = myChart.getDataURL({
                 type: 'png',
                 pixelRatio: 2,
                 backgroundColor: '#fff'
             });
-            a.download = 'missions_graph.png';
+            a.download = 'missions_pie_chart.png';
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);
-        });
-    }
+        }
+    });
 </script>
-
 
 
 

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -83,7 +83,7 @@
     <script>
         function updateFilters() {
             const workerCode = document.getElementById("worker").value;
-            window.location.href = /missions?workerCode=${workerCode};
+            window.location.href = `/missions?workerCode=${workerCode}`;
         }
 
         document.addEventListener("DOMContentLoaded", function() {

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -100,17 +100,20 @@
 
 <!-- Modal -->
 <div id="graphModal" class="fixed inset-0 z-50 hidden bg-black bg-opacity-50 flex items-center justify-center">
-    <div class="bg-white rounded-lg p-6 w-full max-w-3xl relative">
+    <div class="bg-white rounded-lg p-6 w-full max-w-5xl h-[90vh] relative flex flex-col">
         <button id="closeModalBtn" class="absolute top-2 right-2 text-gray-600 hover:text-black text-xl">
             &times;
         </button>
-        <div class="flex justify-between items-center mb-4">
-            <h2 class="text-2xl font-semibold">Pie Chart: Total time per mission group</h2>
+        <h2 class="text-2xl font-semibold mb-4">Pie Chart: Total time per mission group</h2>
+
+        <div id="missionsChart" class="flex-grow" style="width: 100%; height: 100%;"></div>
+
+        <!-- Download button at bottom right -->
+        <div class="mt-4 flex justify-end">
             <button id="downloadBtn" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700">
                 Download
             </button>
         </div>
-        <div id="missionsChart" style="width: 100%; height: 500px;"></div>
     </div>
 </div>
 

--- a/src/main/resources/templates/missions.html
+++ b/src/main/resources/templates/missions.html
@@ -107,11 +107,10 @@
         <button id="closeModalBtn" class="absolute top-2 right-2 text-gray-600 hover:text-black text-xl">
             &times;
         </button>
-        <h2 class="text-2xl font-semibold mb-4">Total time per mission group</h2>
+        <h2 class="text-2xl font-semibold mb-4">Total time spent per mission group</h2>
 
         <div id="missionsChart" class="flex-grow" style="width: 100%; height: 100%;"></div>
 
-        <!-- Download button at bottom right -->
         <div class="mt-4 flex justify-end">
             <button id="downloadBtn" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700">
                 Download

--- a/src/test/java/school/hei/asa/endpoint/rest/mapper/ThWorkerMapperTest.java
+++ b/src/test/java/school/hei/asa/endpoint/rest/mapper/ThWorkerMapperTest.java
@@ -27,30 +27,26 @@ class ThWorkerMapperTest {
 
     @Test
     void can_map_worker_level_histories_to_th() {
-        // Dépendances mockées
         MissionExecutionRepository repo = Mockito.mock(MissionExecutionRepository.class);
         CareProductCodeSupplier supplier = Mockito.mock(CareProductCodeSupplier.class);
 
         ThWorkerMapper mapper = new ThWorkerMapper(repo, supplier);
 
-        // Worker
         Worker worker = new PartnerContractor(
                 "worker-code", "name", "email", "full name",
                 "address", "city", "nif", "stat"
         );
 
-        // Niveau
         JWorkerLevel jLevel = new JWorkerLevel();
         jLevel.setLevel("1");
         jLevel.setLevelId("lvl1");
 
-        // Historique de niveau
         WorkerLevelHistory history = new WorkerLevelHistory(
                 worker,
                 jLevel,
                 Instant.parse("2025-01-01T00:00:00Z"),
-                "fullTimeEmployee",          // doit devenir "Salarié"
-                10,                          // projectedDaysToWork attendu: "10"
+                "fullTimeEmployee",
+                10,
                 BigDecimal.valueOf(1000),
                 "Engineer",
                 12
@@ -64,23 +60,20 @@ class ThWorkerMapperTest {
                 Instant.parse("2025-01-16T00:00:00Z")
         );
 
-        // Comportement mock
         Mockito.when(repo.missionExecutionsByDateBetween(Mockito.eq(worker), Mockito.any(), Mockito.any()))
                 .thenReturn(List.of(me));
-        Mockito.when(supplier.get()).thenReturn("CARE-PRODUCT"); // différent de "pcode" => pas care
+        Mockito.when(supplier.get()).thenReturn("CARE-PRODUCT");
 
-        // Appel
         List<ThWorkerLevelHistory> result = mapper.toTh(List.of(history));
 
-        // Assertions
         assertNotNull(result);
         assertEquals(1, result.size());
 
         ThWorkerLevelHistory th = result.get(0);
         assertEquals("1", th.level());
-        assertEquals("Salarié", th.contractType());       // mapping via switch
-        assertEquals("10", th.projectedDaysToWork());     // car non null
-        assertEquals("0.5", th.actualWorkedDay());        // somme des exécutions
+        assertEquals("Salarié", th.contractType());
+        assertEquals("10", th.projectedDaysToWork());
+        assertEquals("0.5", th.actualWorkedDay());
         assertEquals(BigDecimal.valueOf(1000), th.salary());
         assertEquals("Engineer", th.jobTitle());
         assertEquals(12, th.contractDuration());

--- a/src/test/java/school/hei/asa/endpoint/rest/mapper/ThWorkerMapperTest.java
+++ b/src/test/java/school/hei/asa/endpoint/rest/mapper/ThWorkerMapperTest.java
@@ -1,0 +1,88 @@
+package school.hei.asa.endpoint.rest.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import school.hei.asa.CareProductCodeSupplier;
+import school.hei.asa.endpoint.rest.controller.mapper.ThWorkerMapper;
+import school.hei.asa.endpoint.rest.model.th.ThWorkerLevelHistory;
+import school.hei.asa.model.Mission;
+import school.hei.asa.model.MissionExecution;
+import school.hei.asa.model.PartnerContractor;
+import school.hei.asa.model.Product;
+import school.hei.asa.model.Worker;
+import school.hei.asa.model.WorkerLevelHistory;
+import school.hei.asa.repository.MissionExecutionRepository;
+import school.hei.asa.repository.model.JWorkerLevel;
+
+class ThWorkerMapperTest {
+
+    @Test
+    void can_map_worker_level_histories_to_th() {
+        // Dépendances mockées
+        MissionExecutionRepository repo = Mockito.mock(MissionExecutionRepository.class);
+        CareProductCodeSupplier supplier = Mockito.mock(CareProductCodeSupplier.class);
+
+        ThWorkerMapper mapper = new ThWorkerMapper(repo, supplier);
+
+        // Worker
+        Worker worker = new PartnerContractor(
+                "worker-code", "name", "email", "full name",
+                "address", "city", "nif", "stat"
+        );
+
+        // Niveau
+        JWorkerLevel jLevel = new JWorkerLevel();
+        jLevel.setLevel("1");
+        jLevel.setLevelId("lvl1");
+
+        // Historique de niveau
+        WorkerLevelHistory history = new WorkerLevelHistory(
+                worker,
+                jLevel,
+                Instant.parse("2025-01-01T00:00:00Z"),
+                "fullTimeEmployee",          // doit devenir "Salarié"
+                10,                          // projectedDaysToWork attendu: "10"
+                BigDecimal.valueOf(1000),
+                "Engineer",
+                12
+        );
+
+        // Mission & exécution (0.5 jour)
+        Product product = new Product("pcode", "pname", "pdesc");
+        Mission mission = new Mission("mission-code", "title", "desc", 5, product);
+        MissionExecution me = new MissionExecution(
+                mission, worker, LocalDate.of(2025, 1, 15), 0.5, "comment",
+                Instant.parse("2025-01-16T00:00:00Z")
+        );
+
+        // Comportement mock
+        Mockito.when(repo.missionExecutionsByDateBetween(Mockito.eq(worker), Mockito.any(), Mockito.any()))
+                .thenReturn(List.of(me));
+        Mockito.when(supplier.get()).thenReturn("CARE-PRODUCT"); // différent de "pcode" => pas care
+
+        // Appel
+        List<ThWorkerLevelHistory> result = mapper.toTh(List.of(history));
+
+        // Assertions
+        assertNotNull(result);
+        assertEquals(1, result.size());
+
+        ThWorkerLevelHistory th = result.get(0);
+        assertEquals("1", th.level());
+        assertEquals("Salarié", th.contractType());       // mapping via switch
+        assertEquals("10", th.projectedDaysToWork());     // car non null
+        assertEquals("0.5", th.actualWorkedDay());        // somme des exécutions
+        assertEquals(BigDecimal.valueOf(1000), th.salary());
+        assertEquals("Engineer", th.jobTitle());
+        assertEquals(12, th.contractDuration());
+    }
+}

--- a/src/test/java/school/hei/asa/endpoint/rest/mapper/ThWorkerMapperTest.java
+++ b/src/test/java/school/hei/asa/endpoint/rest/mapper/ThWorkerMapperTest.java
@@ -7,10 +7,8 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import school.hei.asa.CareProductCodeSupplier;
 import school.hei.asa.endpoint.rest.controller.mapper.ThWorkerMapper;
 import school.hei.asa.endpoint.rest.model.th.ThWorkerLevelHistory;
@@ -25,57 +23,61 @@ import school.hei.asa.repository.model.JWorkerLevel;
 
 class ThWorkerMapperTest {
 
-    @Test
-    void can_map_worker_level_histories_to_th() {
-        MissionExecutionRepository repo = Mockito.mock(MissionExecutionRepository.class);
-        CareProductCodeSupplier supplier = Mockito.mock(CareProductCodeSupplier.class);
+  @Test
+  void can_map_worker_level_histories_to_th() {
+    MissionExecutionRepository repo = Mockito.mock(MissionExecutionRepository.class);
+    CareProductCodeSupplier supplier = Mockito.mock(CareProductCodeSupplier.class);
 
-        ThWorkerMapper mapper = new ThWorkerMapper(repo, supplier);
+    ThWorkerMapper mapper = new ThWorkerMapper(repo, supplier);
 
-        Worker worker = new PartnerContractor(
-                "worker-code", "name", "email", "full name",
-                "address", "city", "nif", "stat"
-        );
+    Worker worker =
+        new PartnerContractor(
+            "worker-code", "name", "email", "full name", "address", "city", "nif", "stat");
 
-        JWorkerLevel jLevel = new JWorkerLevel();
-        jLevel.setLevel("1");
-        jLevel.setLevelId("lvl1");
+    JWorkerLevel jLevel = new JWorkerLevel();
+    jLevel.setLevel("1");
+    jLevel.setLevelId("lvl1");
 
-        WorkerLevelHistory history = new WorkerLevelHistory(
-                worker,
-                jLevel,
-                Instant.parse("2025-01-01T00:00:00Z"),
-                "fullTimeEmployee",
-                10,
-                BigDecimal.valueOf(1000),
-                "Engineer",
-                12
-        );
+    WorkerLevelHistory history =
+        new WorkerLevelHistory(
+            worker,
+            jLevel,
+            Instant.parse("2025-01-01T00:00:00Z"),
+            "fullTimeEmployee",
+            10,
+            BigDecimal.valueOf(1000),
+            "Engineer",
+            12);
 
-        // Mission & exécution (0.5 jour)
-        Product product = new Product("pcode", "pname", "pdesc");
-        Mission mission = new Mission("mission-code", "title", "desc", 5, product);
-        MissionExecution me = new MissionExecution(
-                mission, worker, LocalDate.of(2025, 1, 15), 0.5, "comment",
-                Instant.parse("2025-01-16T00:00:00Z")
-        );
+    // Mission & exécution (0.5 jour)
+    Product product = new Product("pcode", "pname", "pdesc");
+    Mission mission = new Mission("mission-code", "title", "desc", 5, product);
+    MissionExecution me =
+        new MissionExecution(
+            mission,
+            worker,
+            LocalDate.of(2025, 1, 15),
+            0.5,
+            "comment",
+            Instant.parse("2025-01-16T00:00:00Z"));
 
-        Mockito.when(repo.missionExecutionsByDateBetween(Mockito.eq(worker), Mockito.any(), Mockito.any()))
-                .thenReturn(List.of(me));
-        Mockito.when(supplier.get()).thenReturn("CARE-PRODUCT");
+    Mockito.when(
+            repo.missionExecutionsByDateBetween(Mockito.eq(worker), Mockito.any(), Mockito.any()))
+        .thenReturn(List.of(me));
+    Mockito.when(supplier.get()).thenReturn("CARE-PRODUCT");
 
-        List<ThWorkerLevelHistory> result = mapper.toTh(List.of(history));
+    List<ThWorkerLevelHistory> result = mapper.toTh(List.of(history));
 
-        assertNotNull(result);
-        assertEquals(1, result.size());
+    assertNotNull(result);
+    assertEquals(1, result.size());
 
-        ThWorkerLevelHistory th = result.get(0);
-        assertEquals("1", th.level());
-        assertEquals("Salarié", th.contractType());
-        assertEquals("10", th.projectedDaysToWork());
-        assertEquals("0.5", th.actualWorkedDay());
-        assertEquals(BigDecimal.valueOf(1000), th.salary());
-        assertEquals("Engineer", th.jobTitle());
-        assertEquals(12, th.contractDuration());
-    }
+    ThWorkerLevelHistory th = result.get(0);
+    assertEquals("1", th.level());
+    assertEquals("Salarié", th.contractType());
+    assertEquals("10", th.projectedDaysToWork());
+    assertEquals("0.5", th.actualWorkedDay());
+    assertEquals(BigDecimal.valueOf(1000), th.salary());
+    assertEquals("Engineer", th.jobTitle());
+    assertEquals(12, th.contractDuration());
+  }
 }


### PR DESCRIPTION
- Refactored ThWorkerMapper.toTh to improve performance when processing worker histories.
- Load all mission executions for the worker in a single query instead of per history.
- Aggregate worked days per date for quick lookup.
- Reduce repeated repository calls, improving frontend loading speed.
- Preserve existing functionality: contract type mapping, projected and actual days, salary, job title, contract duration.
- Added a unit test to verify the correct behavior of the mapper after the refactor.
